### PR TITLE
Pin nginx:alpine to nginx:1.29-alpine and remove unused bash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM nginx:alpine
-
-RUN apk add bash
+FROM nginx:1.29-alpine
 
 COPY default.conf /etc/nginx/conf.d/default.conf
 


### PR DESCRIPTION
## Problems

Two issues in the `Dockerfile`:

1. **Unpinned base image**: `FROM nginx:alpine` — non-reproducible builds (same issue as `melandnat.com`, `resume`, `subalpinedrift`)
2. **Unnecessary `bash` installation**: `RUN apk add bash` — bash is not used anywhere in this Dockerfile. There is no shell script entrypoint, no build step that requires bash, and no CMD/ENTRYPOINT that references it. Its presence:
   - Increases the attack surface (bash is a common target for privilege escalation / exploitation)
   - Adds ~7 MB to the final image with no benefit

## Fix

1. Pin `FROM nginx:alpine` → `FROM nginx:1.29-alpine`
2. Remove `RUN apk add bash`

## Testing

```bash
docker build -t reliableweb .
docker run --rm -p 8080:8080 reliableweb
curl http://localhost:8080/
```

## Audit notes

| Area | Finding | Action |
|------|---------|--------|
| Dockerfile | `FROM nginx:alpine` unpinned | **Fixed (this PR)** |
| Dockerfile | Unnecessary `bash` package installed | **Fixed (this PR)** |
| Content | Static `default.conf`, no dynamic content | No action needed |
