### PR TITLE
chore: Add OCI annotation labels for GHCR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM nginx:1.29-alpine
 
 LABEL org.opencontainers.image.source=https://github.com/icco/reliableweb.dev
-LABEL org.opencontainers.image.description="A static site for a book"
+LABEL org.opencontainers.image.description="A marketing site for book"
 LABEL org.opencontainers.image.licenses=MIT
 
 COPY default.conf /etc/nginx/conf.d/default.conf
 
-ENV PORT 8080
+ENV PORT=8080
 EXPOSE $PORT

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM nginx:1.29-alpine
 
+LABEL org.opencontainers.image.source=https://github.com/icco/reliableweb.dev
+LABEL org.opencontainers.image.description="A static site for a book"
+LABEL org.opencontainers.image.licenses=MIT
+
 COPY default.conf /etc/nginx/conf.d/default.conf
 
 ENV PORT 8080


### PR DESCRIPTION
Adds the GitHub-recommended OCI annotation labels to the Dockerfile so that
the GHCR package page links back to this repo and shows description/license.

See: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images

Labels added to the final image stage:
- `org.opencontainers.image.source`
- `org.opencontainers.image.description`
- `org.opencontainers.image.licenses` (where a recognizable LICENSE exists)